### PR TITLE
Implement Pseudo Class for Dock, increase animation time for snappier reaction

### DIFF
--- a/nosdock.js
+++ b/nosdock.js
@@ -14,7 +14,7 @@ const Convenience = Me.imports.convenience;
 const NosDash = Me.imports.nosdash;
 
 // This will be on settings scheme
-const ANIMATION_TIME = 0.5;
+const ANIMATION_TIME = 0.3;
 const SHOW_DELAY = 0.25;
 const HIDE_DELAY = 0.25;
 


### PR DESCRIPTION
This goes hand in hand with the latest Ozon Shell Theme, this will not affect User Themes unless they are adapting our new #dash:overview pseudo-class, if the User Theme doesn't have it, it just falls back to using the standard #dash class provided in the theme for Desktop Vies as well as for Overview. This reduces hacking into CSS from the extension.

Vice-versa, Ozon Shell Theme will no break stuff if you don't use Atom Dock, since the Gnome Dash never calls for a #dash:overview class it will simpy be ignored.

Theme Maintainers are encouraged (but not enforced) to support this pseudo-class for Atom Dock by simply adding something like:
# dash:overview{ /\* style as seen fit */}

to their Theme. 
