### PR TITLE
Fix dock and message tray behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,48 +28,40 @@ This project is licensed with GPL version 3 and later. See LICENSE for more deta
 
 ### Changelog
 
- * 0.3.2 Changes:
- *  - Fixed Swarm Animation to respect new Dock position
- *  - removed gnomedash.js since it was just a wrapper class for 2 lines of code,
- *    which are now in extension.js
- *  - minor code cleanups
- *
- * 0.3.1 Changes:
- *  - Fixed invisible box which prevent clicking even when dock is hidden
- *  - Show Applications label is now on top of dock
- *  - Icons' popup menu is now on top of dock
- *  - Fix Y position bug when switching workspace between docks with different icon size
- *  - Fix menu popover for Gnome 3.12
- *
- * 0.3 Changes:
- *  - implemented per-workspace-app behavior
- *  - reverse design direction from using :overview to use :desktop pseudo class
- *  - added option to uninstall with "make uninstall"
- *
- * 0.2.2 Changes:
- *  - add pseudo class :overview
- *  - added theme handling when gnome-shell theme changed
- *  - changed all nos-prefixes to atom
- *
- * 0.2.1 Changes:
- *  - change GnomeDash to Lang Class
- *  - fixed drag and drop behavior
- *  - icon label now appear on top of dock
- *  - more cleaning up
- *
- * 0.2 Changes:
- *  - added intellihide.js, implemented intellihide
- *
- * 0.1.1 Changes:
- *  - remove hardcoded css, add theme support
- *  - added Legacy Overview padding-bottom so its elements won't be behind dock
- *  - fixed incorrect icon sizes on some initialization
- *  - implemented 75% of screen width as maximum dock width instead of 100%
- *  - changed possible icon size range to 24-48px for esthetic reasons
- *
- * 0.1 Changes:
- *  - added NosDock to contain NosDash and handle intellihide behaviors
- *  - added NosDash containing favorite and running apps list
- *  - hide dock's background on overview, taken from nos-panel
- *  - convert indentation to spaces, added emacs header line
- 
+* 0.3.2 Changes:
+ * Fixed Swarm Animation to respect new Dock position
+   removed gnomedash.js since it was just a wrapper class for 2 lines of code,
+   which are now in extension.js
+ * minor code cleanups
+* 0.3.1 Changes:
+ * Fixed invisible box which prevent clicking even when dock is hidden
+ * Show Applications label is now on top of dock
+ * Icons' popup menu is now on top of dock
+ * Fix Y position bug when switching workspace between docks with different icon size
+ * Fix menu popover for Gnome 3.12
+* 0.3 Changes:
+ * implemented per-workspace-app behavior
+ * reverse design direction from using :overview to use :desktop pseudo class
+ * added option to uninstall with "make uninstall"
+* 0.2.2 Changes:
+ * add pseudo class :overview
+ * added theme handling when gnome-shell theme changed
+ * changed all nos-prefixes to atom
+* 0.2.1 Changes:
+ * change GnomeDash to Lang Class
+ * fixed drag and drop behavior
+ * icon label now appear on top of dock
+ * more cleaning up
+* 0.2 Changes:
+ * added intellihide.js, implemented intellihide
+* 0.1.1 Changes:
+ * remove hardcoded css, add theme support
+ * added Legacy Overview padding-bottom so its elements won't be behind dock
+ * fixed incorrect icon sizes on some initialization
+ * implemented 75% of screen width as maximum dock width instead of 100%
+ * changed possible icon size range to 24-48px for esthetic reasons
+* 0.1 Changes:
+ * added NosDock to contain NosDash and handle intellihide behaviors
+ * added NosDash containing favorite and running apps list
+ * hide dock's background on overview, taken from nos-panel
+ * convert indentation to spaces, added emacs header line

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ This project is licensed with GPL version 3 and later. See LICENSE for more deta
 
 * 0.3.2 Changes:
  * Fixed Swarm Animation to respect new Dock position
-   removed gnomedash.js since it was just a wrapper class for 2 lines of code,
+ * Removed gnomedash.js since it was just a wrapper class for 2 lines of code,
    which are now in extension.js
- * minor code cleanups
+ * Minor code cleanups
 * 0.3.1 Changes:
  * Fixed invisible box which prevent clicking even when dock is hidden
  * Show Applications label is now on top of dock

--- a/atomdock.js
+++ b/atomdock.js
@@ -8,6 +8,7 @@ const Signals = imports.signals;
 const Clutter = imports.gi.Clutter;
 const Gtk = imports.gi.Gtk;
 const St = imports.gi.St;
+const Shell = imports.gi.Shell;
 
 const Main = imports.ui.main;
 const Tweener = imports.ui.tweener;
@@ -38,6 +39,9 @@ const AtomDock = new Lang.Class({
 
         // Overview shown status
         this.forcedOverview = false;
+
+        // Contain tray dwell timeout function
+        this._myDwell = 0;
 
         // Put dock on the primary monitor
         this._monitor = Main.layoutManager.primaryMonitor;
@@ -97,7 +101,7 @@ const AtomDock = new Lang.Class({
                /* What if the Message Tray is removed in 3.16 ? Then this might blow up */
                Main.messageTray,
                 'showing',
-                Lang.bind(this, this._hide)       
+                Lang.bind(this, this._hoverChanged)
             ]
         );
 
@@ -346,6 +350,36 @@ const AtomDock = new Lang.Class({
                 this._hide();
             }
         }
+        // Disable message tray pressure on enter hover, enable it on out of hover
+        if (this._box.hover) {
+            this._disableMessageTrayPressure();
+        } else {
+            this._enableMessageTrayPressure();
+        }
+    },
+
+    // Enabling disabling message tray pressure credit to
+    // https://github.com/tuxor1337/insensitive-message-tray
+    _disableMessageTrayPressure: function() {
+        if("_trayPressure" in Main.layoutManager) {
+            Main.layoutManager._trayPressure._keybindingMode =
+                Shell.KeyBindingMode.OVERVIEW;
+        }
+        this._myDwell = Main.messageTray._trayDwellTimeout;
+        Main.messageTray._trayDwellTimeout = function() { return false; };
+        global.log("test");
+    },
+
+    _enableMessageTrayPressure: function() {
+        if("_trayPressure" in Main.layoutManager) {
+            Main.layoutManager._trayPressure._keybindingMode =
+                Shell.KeyBindingMode.NORMAL | Shell.KeyBindingMode.OVERVIEW;
+        }
+        if(this._myDwell) {
+            Main.messageTray._trayDwellTimeout = _myDwell;
+            this._myDwell = 0;
+        }
+        global.log("test2");
     },
 
     _show: function() {

--- a/atomdock.js
+++ b/atomdock.js
@@ -367,7 +367,6 @@ const AtomDock = new Lang.Class({
         }
         this._myDwell = Main.messageTray._trayDwellTimeout;
         Main.messageTray._trayDwellTimeout = function() { return false; };
-        global.log("test");
     },
 
     _enableMessageTrayPressure: function() {
@@ -376,10 +375,9 @@ const AtomDock = new Lang.Class({
                 Shell.KeyBindingMode.NORMAL | Shell.KeyBindingMode.OVERVIEW;
         }
         if(this._myDwell) {
-            Main.messageTray._trayDwellTimeout = _myDwell;
+            Main.messageTray._trayDwellTimeout = this._myDwell;
             this._myDwell = 0;
         }
-        global.log("test2");
     },
 
     _show: function() {

--- a/atomdock.js
+++ b/atomdock.js
@@ -96,12 +96,6 @@ const AtomDock = new Lang.Class({
                 Main.overview,
                 'hiding',
                 Lang.bind(this, this._setOpaque)
-            ],
-            [
-               /* What if the Message Tray is removed in 3.16 ? Then this might blow up */
-               Main.messageTray,
-                'showing',
-                Lang.bind(this, this._hoverChanged)
             ]
         );
 

--- a/extension.js
+++ b/extension.js
@@ -6,15 +6,13 @@
  * Extension's version: 0.3.2
  *
  * Changelog was moved to README.md
- * 
+ *
  * TODO(s):
- *  - bug on each initialization, dock stuck not hiding until hovered out
  *  - add animation of adding-removing app icon on redisplay and only shows that
  *    animation when dock is not hidden
- *  - app label only shows when animation not running (see #18)
  *  - check behavior on multiple monitor
  *  - add settings schema
- *  - implement workspace button    
+ *  - implement workspace button
  */
 
 const ExtensionUtils = imports.misc.extensionUtils;
@@ -84,21 +82,19 @@ function hide() {
     atomDock.enableAutoHide();
 }
 
-function init() {
-       
-}
+function init() { }
 
 function enable() {
-    /* Make sure we don't see the old Dash anymore */    
-    Main.overview._dash.actor.get_parent().hide();    
-    oldDash = Main.overview._dash; 
+    /* Make sure we don't see the old Dash anymore */
+    Main.overview._dash.actor.get_parent().hide();
+    oldDash = Main.overview._dash;
 
     /* Enable new dock */
     atomDock = new AtomDock.AtomDock();
     intellihide = new Intellihide.Intellihide(show, hide, atomDock);
 
-    /* Make Shell respect our custom Dock as the 'real deal' :) */    
-    Main.overview._dash = atomDock.dash;    
+    /* Make Shell respect our custom Dock as the 'real deal' :) */
+    Main.overview._dash = atomDock.dash;
 
     injections['_redisplay'] = undefined;
 
@@ -175,18 +171,18 @@ function enable() {
 function disable() {
     intellihide.destroy();
     atomDock.destroy();
-    
-    /*Make sure the original Dock is usable after disabling Atom Dock*/        
-    Main.overview._dash = oldDash;    
+
+    /* Make sure the original Dock is usable after disabling Atom Dock */
+    Main.overview._dash = oldDash;
     Main.overview._dash.actor.get_parent().show();
 
     for (i in injections) {
         removeInjection(AppDisplay.AppIconMenu.prototype, injections, i);
     }
 
-    /*Cleanup*/    
+    /* Cleanup */
     injections = {};
-    atomDock= null;
-    intellihide=null;
-    oldDash=null;    
+    atomDock = null;
+    intellihide = null;
+    oldDash = null;
 }

--- a/intellihide.js
+++ b/intellihide.js
@@ -125,6 +125,18 @@ const Intellihide = new Lang.Class({
                 global.screen,
                 'monitors-changed',
                 Lang.bind(this, this._updateDockVisibility)
+            ],
+            [
+                /* What if the Message Tray is removed in 3.16 ? Then this might blow up */
+                Main.messageTray,
+                'showing',
+                Lang.bind(this, this._forceHide)
+            ],
+            [
+                /* What if the Message Tray is removed in 3.16 ? Then this might blow up */
+                Main.messageTray,
+                'hiding',
+                Lang.bind(this, this._onMessageTrayHiding)
             ]
         );
 
@@ -155,6 +167,12 @@ const Intellihide = new Lang.Class({
 
     },
 
+    _forceHide: function() {
+
+        this._hide(true);
+
+    },
+
     _hide: function(force) {
 
         if (this.status !== false || force) {
@@ -162,6 +180,13 @@ const Intellihide = new Lang.Class({
             this.hideFunction();
         }
 
+    },
+
+    _onMessageTrayHiding: function() {
+        // Wait until message tray finished hiding, then update dock visibility
+        Mainloop.timeout_add(Main.messageTray.ANIMATION_TIME, Lang.bind(this, function() {
+            this._updateDockVisibility();
+        }));
     },
 
     _overviewExit: function() {


### PR DESCRIPTION
Fixes #41. Dock and Message Tray should be happily coexist now. Dock is always hidden when Message Tray is showing, and when Message Tray is hiding, it will readjust (showing/hiding) based on intellihide. Message Tray won't be opened when mouse is hovering the Dock.

One problem though, when Dock is open and hovered on, pressing Super+M will open Message Tray and the Dock will be stuck open until hovered out. Can't fix it yet.