### PR TITLE
Added support for Gnome Shell 3.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A custom Dock Extension for Gnome Shell. This Extension is part of the Atom Exte
 | 3.10 | ??? |
 | 3.12 | yes |
 | 3.14 | yes |
-| 3.16 | ??? |
+| 3.16 | yes |
 
 ### Installation
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.10", "3.12", "3.14"],
+    "shell-version": ["3.10", "3.12", "3.14", "3.16"],
     "uuid": "atom-dock@ozonos.org",
     "name": "Atom Dock",
     "description": "Custom Dock for Ozon Desktop"


### PR DESCRIPTION
I am testing Atom dock with Gnome 3.16 (released today) and everything seems to work fine so i am requesting a merge for that version to the metadata.json file